### PR TITLE
Remove variables from global scope

### DIFF
--- a/lib/addon/easing.js
+++ b/lib/addon/easing.js
@@ -20,9 +20,9 @@ function Easing(token) {
   if (!match || !match.length) {
     return _identity;
   }
-  easing = _easings[match[1]];
-  mode = _modes[match[3]];
-  params = match[5];
+  var easing = _easings[match[1]];
+  var mode = _modes[match[3]];
+  var params = match[5];
   if (easing && easing.fn) {
     fn = easing.fn;
   } else if (easing && easing.fc) {


### PR DESCRIPTION
Preventing variables from bleeding into the global scope